### PR TITLE
Update entities.py

### DIFF
--- a/custom_components/nexa_bridge_x/entities.py
+++ b/custom_components/nexa_bridge_x/entities.py
@@ -77,8 +77,8 @@ class NexaNodeEntity(NexaEntity):
 
 class NexaDimmerEntity(NexaNodeEntity, LightEntity):
     """Entity for light"""
-    _attr_color_mode = ColorMode.BRIGHTNESS
-    _attr_supported_color_modes = {ColorMode.ONOFF, ColorMode.BRIGHTNESS}
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     def __init__(self, coordinator: DataUpdateCoordinator, node: NexaNode):
         _LOGGER.info("Found light %s: %s", node.id, node.name)


### PR DESCRIPTION
These changes takes care of the warning & potential issue:

2024-03-30 22:12:52.582 WARNING (MainThread) [homeassistant.components.light] None (<class 'custom_components.nexa_bridge_x.entities.NexaDimmerEntity'>) sets invalid supported color modes {<ColorMode.BRIGHTNESS: 'brightness'>, <ColorMode.ONOFF: 'onoff'>}, this will stop working in Home Assistant Core 2025.3, please create a bug report at https://github.com/andersevenrud/ha-nexa-bridge-x/issues